### PR TITLE
Implement investment for MIMO

### DIFF
--- a/oemof_industry/mimo_converter.py
+++ b/oemof_industry/mimo_converter.py
@@ -150,7 +150,8 @@ class MultiInputMultiOutputConverter(Node):
         # Add emissions to outputs (as they are excluded from output groups before)
         outputs = reduce(operator.ior, self.output_groups.values(), {}) | emissions
 
-        # If primary is not set, define it as first output, otherwise search for primary string in inputs and outputs
+        # Primary bus is defined as the bus holding an investment.
+        # If no bus is holding an investment, primary bus is set to None
         buses_holding_investment = [bus for bus, flow in (inputs | outputs).items() if flow.investment is not None]
         if len(buses_holding_investment) > 1:
             raise ValueError("Only one investment allowed.")

--- a/tests/test_mimo_converter.py
+++ b/tests/test_mimo_converter.py
@@ -7,9 +7,7 @@ SPDX-License-Identifier: MIT
 import pandas as pd
 import pytest
 
-from oemof.solph import EnergySystem
-from oemof.solph import Model
-from oemof.solph import processing
+from oemof.solph import EnergySystem, Model, Investment, processing
 from oemof.solph.buses import Bus
 from oemof.solph.components import Sink
 from oemof.solph.components import Source
@@ -124,7 +122,7 @@ def test_flow_shares():
     # resources
     b_gas = Bus(label="gas")
     es.add(b_gas)
-    es.add(Source(label="gas_station", outputs={b_gas: Flow(variable_costs=20)}))
+    es.add(Source(label="gas_station", outputs={b_gas: Flow(nominal_value=Investment(ep_costs=1), variable_costs=20)}))
 
     b_hydro = Bus(label="hydro")
     es.add(b_hydro)

--- a/tests/test_mimo_costs.py
+++ b/tests/test_mimo_costs.py
@@ -1,0 +1,132 @@
+# -*- coding: utf-8 -*-
+"""
+Example that illustrates how to use component `MultiInputMultiOutputConverter`.
+
+SPDX-License-Identifier: MIT
+"""
+import pandas as pd
+from oemof.solph import EnergySystem, Investment, Model, processing
+from oemof.solph.buses import Bus
+from oemof.solph.components import Sink, Source
+from oemof.solph.flows import Flow
+
+from oemof_industry.mimo_converter import MultiInputMultiOutputConverter
+
+
+def test_investment_fix_outputs():
+    idx = pd.date_range("1/1/2017", periods=2, freq="H")
+    es = EnergySystem(timeindex=idx)
+
+    # resources
+    b_gas = Bus(label="gas")
+    es.add(b_gas)
+    es.add(Source(label="gas_station", outputs={b_gas: Flow(variable_costs=2)}))
+
+    b_hydro = Bus(label="hydro")
+    es.add(b_hydro)
+    es.add(Source(label="hydro_station", outputs={b_hydro: Flow(variable_costs=3)}))
+
+    b_electricity = Bus(label="electricity", balanced=False)
+    es.add(b_electricity)
+
+    b_heat = Bus(label="heat", balanced=True)
+    es.add(b_heat)
+
+    b_heat_low = Bus(label="heat_low", balanced=False)
+    es.add(b_heat)
+
+    es.add(Source(label="heat_import", outputs={b_heat: Flow(nominal_value=Investment(ep_costs=200), variable_costs=200)}))
+
+    es.add(
+        Sink(
+            label="demand",
+            inputs={b_heat: Flow(fix=[100, 80], nominal_value=1)},
+        )
+    )
+
+    es.add(
+        MultiInputMultiOutputConverter(
+            label="mimo",
+            inputs={"in": {b_gas: Flow(), b_hydro: Flow()}},
+            outputs={
+                b_electricity: Flow(nominal_value=Investment(ep_costs=1.2, maximum=20)),
+                "heat": {b_heat: Flow(), b_heat_low: Flow()},
+            },
+            conversion_factors={b_gas: 1.2, b_hydro: 1.3, b_heat: 1.2},
+            flow_shares={"fix": {b_gas: [0.8, 0.3], b_heat: 0.8}},
+        )
+    )
+
+    # create an optimization problem and solve it
+    om = Model(es)
+
+    # solve model
+    om.solve(solver="cbc")
+
+    # create result object
+    results = processing.convert_keys_to_strings(processing.results(om))
+
+    assert results[("mimo", "electricity")]["scalars"]["invest"] == 20
+
+    assert results[("mimo", "heat")]["sequences"]["flow"].values[0] == 20 * 0.8 * 1.2
+    assert results[("heat_import", "heat")]["sequences"]["flow"].values[0] == 100 - 20 * 0.8 * 1.2
+    assert results[("mimo", "electricity")]["sequences"]["flow"].values[0] == 20
+
+
+def test_investment_var_outputs():
+    idx = pd.date_range("1/1/2017", periods=2, freq="H")
+    es = EnergySystem(timeindex=idx)
+
+    # resources
+    b_gas = Bus(label="gas")
+    es.add(b_gas)
+    es.add(Source(label="gas_station", outputs={b_gas: Flow(variable_costs=2)}))
+
+    b_hydro = Bus(label="hydro")
+    es.add(b_hydro)
+    es.add(Source(label="hydro_station", outputs={b_hydro: Flow(variable_costs=3)}))
+
+    b_electricity = Bus(label="electricity", balanced=False)
+    es.add(b_electricity)
+
+    b_heat = Bus(label="heat", balanced=True)
+    es.add(b_heat)
+
+    es.add(Source(label="heat_import", outputs={b_heat: Flow(variable_costs=200)}))
+
+    es.add(
+        Sink(
+            label="demand",
+            inputs={b_heat: Flow(fix=[100, 100], nominal_value=1)},
+        )
+    )
+
+    es.add(
+        MultiInputMultiOutputConverter(
+            label="mimo",
+            inputs={"in": {b_gas: Flow(), b_hydro: Flow()}},
+            outputs={
+                "out": {
+                    b_electricity: Flow(nominal_value=Investment(ep_costs=1.2, maximum=20)),
+                    b_heat: Flow()
+                },
+            },
+            conversion_factors={b_gas: 1.2, b_hydro: 1.3, b_heat: 1.2},
+            flow_shares={"fix": {b_gas: [0.8, 0.3]}},
+        )
+    )
+
+    # create an optimization problem and solve it
+    om = Model(es)
+
+    # solve model
+    om.solve(solver="cbc")
+
+    # create result object
+    results = processing.convert_keys_to_strings(processing.results(om))
+
+    assert results[("mimo", "electricity")]["scalars"]["invest"] == 20
+
+    assert results[("mimo", "heat")]["sequences"]["flow"].values[0] == 20 * 1.2
+    assert results[("heat_import", "heat")]["sequences"]["flow"].values[0] == 100 - 20 * 1.2
+    assert results[("mimo", "electricity")]["sequences"]["flow"].values[0] == 0


### PR DESCRIPTION
Closes #4 

This can be used in facade in order to set up investment for a primary bus.
As flows are generated automatically in facade and investment differs depending on putting it on input or output flow, maybe we should add a parameter `primary: str` which defines on which bus aka flow the investment should be put?!