### PR TITLE
Fix IIS mimo test

### DIFF
--- a/tests/test_mimo_converter.py
+++ b/tests/test_mimo_converter.py
@@ -804,7 +804,7 @@ def test_industry_component_IIS_CHPSTMGAS101_LB():
                 b_ch4: {"out": 0.0017},
                 b_n2o: {"out": 0.0031},
             },
-            conversion_factors={"out": [0.455, 0.46, 0.46, 0.46, 0.46, 0.46]},
+            conversion_factors={"out": [0.81621384872728, 0.816756629427805, 0.816756629427805, 0.816756629427805, 0.816756629427805, 0.816756629427805]},
             flow_shares={"fix": {b_hydro: [0.5, 1, 1, 1, 1, 1]}},
         )
     )

--- a/tests/test_mimo_converter.py
+++ b/tests/test_mimo_converter.py
@@ -822,7 +822,7 @@ def test_industry_component_IIS_CHPSTMGAS101_LB():
     # Gas
     assert results[("IISGAS-LB", "mimo")]["sequences"]["flow"].values[
         0
-    ] == pytest.approx(5.4945)  # todo acutal 9.8561538
+    ] == pytest.approx(5.4945, abs=1e-3)
     assert results[("IISGAS-LB", "mimo")]["sequences"]["flow"].values[
         1
     ] == pytest.approx(0)
@@ -841,22 +841,22 @@ def test_industry_component_IIS_CHPSTMGAS101_LB():
     # Hydro
     assert results[("IISHH2-LB", "mimo")]["sequences"]["flow"].values[
         0
-    ] == pytest.approx(5.4945)  # todo actual 9.8561538
+    ] == pytest.approx(5.4945, abs=1e-2)
     assert results[("IISHH2-LB", "mimo")]["sequences"]["flow"].values[
         1
-    ] == pytest.approx(10.8696)  # todo actual 19.29913
+    ] == pytest.approx(10.8696, abs=1e-3)
     assert results[("IISHH2-LB", "mimo")]["sequences"]["flow"].values[
         2
-    ] == pytest.approx(10.8696)  # todo actual 19.29913
+    ] == pytest.approx(10.8696, abs=1e-3)
     assert results[("IISHH2-LB", "mimo")]["sequences"]["flow"].values[
         3
-    ] == pytest.approx(10.8696)  # todo actual 19.29913
+    ] == pytest.approx(10.8696, abs=1e-3)
     assert results[("IISHH2-LB", "mimo")]["sequences"]["flow"].values[
         4
-    ] == pytest.approx(10.8696)  # todo actual 19.29913
+    ] == pytest.approx(10.8696, abs=1e-3)
     assert results[("IISHH2-LB", "mimo")]["sequences"]["flow"].values[
         5
-    ] == pytest.approx(10.8696)  # todo actual 19.29913
+    ] == pytest.approx(10.8696, abs=1e-3)
 
     # OUTPUTS
     # Heat (Primary)
@@ -899,7 +899,7 @@ def test_industry_component_IIS_CHPSTMGAS101_LB():
     )
     # CO2
     assert results[("mimo", "INDCO2N")]["sequences"]["flow"].values[0] == pytest.approx(
-        307.6923
+        307.6923, abs=1e-2
     )
     assert results[("mimo", "INDCO2N")]["sequences"]["flow"].values[1] == pytest.approx(
         0

--- a/tests/test_mimo_converter.py
+++ b/tests/test_mimo_converter.py
@@ -758,7 +758,8 @@ def test_industry_component_IIS_CHPSTMGAS101_LB():
             label="el_demand",
             inputs={
                 b_elec: Flow(
-                    fix=[3.9485, 3.9592, 3.9694, 3.9796, 3.9796, 3.9796], nominal_value=1
+                    fix=[3.9485, 3.9592, 3.9694, 3.9796, 3.9796, 3.9796],
+                    nominal_value=1,
                 )
             },
         )
@@ -804,7 +805,16 @@ def test_industry_component_IIS_CHPSTMGAS101_LB():
                 b_ch4: {"out": 0.0017},
                 b_n2o: {"out": 0.0031},
             },
-            conversion_factors={"out": [0.81621384872728, 0.816756629427805, 0.816756629427805, 0.816756629427805, 0.816756629427805, 0.816756629427805]},
+            conversion_factors={
+                "out": [
+                    0.81621384872728,
+                    0.816756629427805,
+                    0.816756629427805,
+                    0.816756629427805,
+                    0.816756629427805,
+                    0.816756629427805,
+                ]
+            },
             flow_shares={"fix": {b_hydro: [0.5, 1, 1, 1, 1, 1]}},
         )
     )
@@ -860,24 +870,24 @@ def test_industry_component_IIS_CHPSTMGAS101_LB():
 
     # OUTPUTS
     # Heat (Primary)
-    assert results[("mimo", "IISHTH-LB")]["sequences"]["flow"].values[0] == pytest.approx(
-        5.0206
-    )
-    assert results[("mimo", "IISHTH-LB")]["sequences"]["flow"].values[1] == pytest.approx(
-        4.9184
-    )
-    assert results[("mimo", "IISHTH-LB")]["sequences"]["flow"].values[2] == pytest.approx(
-        4.9082
-    )
-    assert results[("mimo", "IISHTH-LB")]["sequences"]["flow"].values[3] == pytest.approx(
-        4.898
-    )
-    assert results[("mimo", "IISHTH-LB")]["sequences"]["flow"].values[4] == pytest.approx(
-        4.898
-    )
-    assert results[("mimo", "IISHTH-LB")]["sequences"]["flow"].values[5] == pytest.approx(
-        4.898
-    )
+    assert results[("mimo", "IISHTH-LB")]["sequences"]["flow"].values[
+        0
+    ] == pytest.approx(5.0206)
+    assert results[("mimo", "IISHTH-LB")]["sequences"]["flow"].values[
+        1
+    ] == pytest.approx(4.9184)
+    assert results[("mimo", "IISHTH-LB")]["sequences"]["flow"].values[
+        2
+    ] == pytest.approx(4.9082)
+    assert results[("mimo", "IISHTH-LB")]["sequences"]["flow"].values[
+        3
+    ] == pytest.approx(4.898)
+    assert results[("mimo", "IISHTH-LB")]["sequences"]["flow"].values[
+        4
+    ] == pytest.approx(4.898)
+    assert results[("mimo", "IISHTH-LB")]["sequences"]["flow"].values[
+        5
+    ] == pytest.approx(4.898)
     # CH4
     assert results[("mimo", "INDCH4N")]["sequences"]["flow"].values[0] == pytest.approx(
         0.0149, abs=1e-3
@@ -951,11 +961,7 @@ def test_industry_component_CHPIFTGAS00():
     es.add(
         Sink(
             label="el_demand",
-            inputs={
-                b_elec: Flow(
-                    fix=[4.0842, 4.2743, 4.2743], nominal_value=1
-                )
-            },
+            inputs={b_elec: Flow(fix=[4.0842, 4.2743, 4.2743], nominal_value=1)},
         )
     )
 
@@ -964,11 +970,7 @@ def test_industry_component_CHPIFTGAS00():
     es.add(
         Sink(
             label="heat_demand",
-            inputs={
-                b_heat: Flow(
-                    fix=[6.8071, 7.124, 7.124], nominal_value=1
-                )
-            },
+            inputs={b_heat: Flow(fix=[6.8071, 7.124, 7.124], nominal_value=1)},
         )
     )
 
@@ -1036,15 +1038,15 @@ def test_industry_component_CHPIFTGAS00():
         7.124
     )
     # Electricity (Primary)
-    assert results[("mimo", "IISELC-LB")]["sequences"]["flow"].values[0] == pytest.approx(
-        4.0842
-    )
-    assert results[("mimo", "IISELC-LB")]["sequences"]["flow"].values[1] == pytest.approx(
-        4.2743
-    )
-    assert results[("mimo", "IISELC-LB")]["sequences"]["flow"].values[2] == pytest.approx(
-        4.2743
-    )
+    assert results[("mimo", "IISELC-LB")]["sequences"]["flow"].values[
+        0
+    ] == pytest.approx(4.0842)
+    assert results[("mimo", "IISELC-LB")]["sequences"]["flow"].values[
+        1
+    ] == pytest.approx(4.2743)
+    assert results[("mimo", "IISELC-LB")]["sequences"]["flow"].values[
+        2
+    ] == pytest.approx(4.2743)
     # CH4
     assert results[("mimo", "INDCH4N")]["sequences"]["flow"].values[0] == pytest.approx(
         0.0121, rel=1e-2


### PR DESCRIPTION
Fixes test for  industry component IIS_CHPSTMGAS101_LB. 

Adapts especially conversion factors of the component according to new information:
The new conversion factor was calculated by a formula that takes into consideration the pass-out turbine characteristics. 