### PR TITLE
Add lifetime as attribute of MIMO facade

### DIFF
--- a/oemof_industry/mimo_converter.py
+++ b/oemof_industry/mimo_converter.py
@@ -749,6 +749,7 @@ class MIMO(MultiInputMultiOutputConverter, Facade):
         self.expandable: bool = kwargs.get("expandable", False)
         self.capacity_potential: float = kwargs.get("capacity_potential", float("+inf"))
         self.capacity_minimum: float = kwargs.get("capacity_minimum")
+        self.lifetime: int = kwargs.get("lifetime")
 
         inputs, outputs = self._init_inputs_and_outputs(buses, kwargs)
         conversion_factors = self._init_efficiencies(buses, groups, kwargs)


### PR DESCRIPTION
To fix error in multi-period optimization:
`ValueError: You have to specify a lifetime for a Flow with an associated investment object in a multi-period model!`