### PR TITLE
Adapt emission constraint for multi-period optimization

### DIFF
--- a/oemof_industry/emission_constraint.py
+++ b/oemof_industry/emission_constraint.py
@@ -106,7 +106,7 @@ class CO2EmissionLimit(ConstraintFacade):
     """
     type: str
     co2_limit: float
-    ch4_factor: float = 258
+    ch4_factor: float = 28
     n2o_factor: float = 265
     commodities: dict = field(default_factory=dict)
 


### PR DESCRIPTION
Before the co2 limit was set for the whole optimization. In case of
multi-period it is useful to be able to set a co2 limit for each period.
This is triggered by defining co2_limit as list, with each entry
representing the yearly co2 limit for a period.